### PR TITLE
[IMP] account_credit_control: view credit control: group by effective…

### DIFF
--- a/account_credit_control/line_view.xml
+++ b/account_credit_control/line_view.xml
@@ -85,8 +85,10 @@
 
           <newline/>
           <group string="Group By...">
-            <filter domain='[]' context="{'group_by': 'date'}"
+            <filter domain='[]' context="{'group_by': 'date:day'}"
                     string="Run date"/>
+            <filter domain='[]' context="{'group_by': 'state'}"
+                    string="State"/>
             <filter domain='[]' context="{'group_by': 'level'}"
                     string="Level"/>
             <filter domain='[]' context="{'group_by': 'partner_id'}"


### PR DESCRIPTION
… run date and not month, add group by state

I think it's more practical to see the lines grouped by effective run dates. This allows to differentiate multiple run in a month. Having group by state is also quite practical.
